### PR TITLE
Fix issue #3: allow making existing bookmarks public

### DIFF
--- a/client/src/components/EditBookmark/EditBookmark.tsx
+++ b/client/src/components/EditBookmark/EditBookmark.tsx
@@ -12,6 +12,7 @@ interface EditBookmarkProps {
 export const EditBookmark = ({ bookmark, onSave, onClose }: EditBookmarkProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const [title, setTitle] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveErrorStatus, setSaveErrorStatus] = useState<number | null>(null);
@@ -37,6 +38,7 @@ export const EditBookmark = ({ bookmark, onSave, onClose }: EditBookmarkProps) =
     setSaveErrorStatus(null);
     if (bookmark) {
       setTitle(bookmark.title);
+      setIsPublic(bookmark.isPublic);
     }
     onClose();
   }, [bookmark, onClose]);
@@ -45,8 +47,9 @@ export const EditBookmark = ({ bookmark, onSave, onClose }: EditBookmarkProps) =
   useEffect(() => {
     if (bookmark) {
       setTitle(bookmark.title);
+      setIsPublic(bookmark.isPublic);
     }
-  }, [bookmark?.title]);
+  }, [bookmark?.title, bookmark?.isPublic]);
 
   // Show modal when bookmark changes
   useEffect(() => {
@@ -82,7 +85,7 @@ export const EditBookmark = ({ bookmark, onSave, onClose }: EditBookmarkProps) =
 
     try {
       // Update bookmark title via API
-      const updatedBookmark = await updateBookmark(bookmark.id, { title: title.trim() });
+      const updatedBookmark = await updateBookmark(bookmark.id, { title: title.trim(), isPublic });
 
       // Dispatch custom events to notify other components
       // Pass the updated bookmark in the event detail to avoid full page reload
@@ -139,6 +142,19 @@ export const EditBookmark = ({ bookmark, onSave, onClose }: EditBookmarkProps) =
                   autoFocus
                 />
               </div>
+              <div className="form-check">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  id="bookmark-is-public-input"
+                  checked={isPublic}
+                  onChange={(e) => setIsPublic(e.target.checked)}
+                  disabled={isSaving}
+                />
+                <label className="form-check-label" htmlFor="bookmark-is-public-input">
+                  Public
+                </label>
+              </div>
             </div>
             <div className="modal-footer">
               <button
@@ -152,7 +168,7 @@ export const EditBookmark = ({ bookmark, onSave, onClose }: EditBookmarkProps) =
               <button
                 type="submit"
                 className="btn btn-primary"
-                disabled={isSaving || !title.trim() || (bookmark ? title.trim() === bookmark.title : false)}
+                disabled={isSaving || !title.trim() || (bookmark ? (title.trim() === bookmark.title && isPublic === bookmark.isPublic) : false)}
               >
                 {isSaving ? (
                   <>

--- a/server/src/Api/Controller/MeBookmarkController.php
+++ b/server/src/Api/Controller/MeBookmarkController.php
@@ -436,6 +436,8 @@ final class MeBookmarkController extends BookmarkController
         )]
         BookmarkApiDto $bookmarkPayload,
     ): JsonResponse {
+        $wasPublic = $bookmark->isPublic;
+
         // Manual merge
         if (isset($bookmarkPayload->title)) {
             $bookmark->title = $bookmarkPayload->title;
@@ -461,6 +463,10 @@ final class MeBookmarkController extends BookmarkController
             $this->entityManager->persist($indexAction);
 
             $this->entityManager->flush();
+
+            if (!$wasPublic && $bookmark->isPublic) {
+                $this->messageBus->dispatch(new SendCreateNoteMessage($bookmark->id));
+            }
         } catch (ORMInvalidArgumentException|ORMException $e) {
             throw new UnprocessableEntityHttpException(previous: $e);
         }

--- a/server/tests/Api/Controller/BookmarkTest.php
+++ b/server/tests/Api/Controller/BookmarkTest.php
@@ -555,6 +555,33 @@ class BookmarkTest extends BaseApiTestCase
         $this->assertCount(0, $json['tags'], 'All tags should be removed');
     }
 
+    public function testEditOwnBookmarkCanToggleVisibilityToPublic(): void
+    {
+        [, $token, $account] = $this->createAuthenticatedUserAccount('testuser', 'test');
+
+        $bookmark = BookmarkFactory::createOne([
+            'account' => $account,
+            'title' => 'Private Bookmark',
+            'url' => 'https://example.com/private',
+            'isPublic' => false,
+        ]);
+
+        $this->request('PATCH', "/users/me/bookmarks/{$bookmark->id}", [
+            'headers' => ['Content-Type' => 'application/json'],
+            'auth_bearer' => $token,
+            'json' => [
+                'isPublic' => true,
+            ],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $json = $this->dump($this->getResponseArray());
+        $this->assertTrue($json['isPublic'], 'Bookmark should become public after PATCH update.');
+
+        $this->request('GET', "/profile/testuser/bookmarks/{$bookmark->id}");
+        $this->assertResponseIsSuccessful();
+    }
+
     public function testDeleteOwnBookmark(): void
     {
         [, $token, $account] = $this->createAuthenticatedUserAccount('testuser', 'test');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow `PATCH /users/me/bookmarks/{id}` to publish existing bookmarks by dispatching ActivityPub create when visibility changes from private to public
- add API regression coverage ensuring a bookmark can be switched to public and then fetched from the public profile endpoint
- update the client edit bookmark modal to support editing visibility (`isPublic`) in addition to title

## Scope
- changed: `server` (API) and `client`
- not changed: extension, shared, docs, infrastructure, other components

## Testing
- attempted `server` PHPUnit target, but `php` is not available in this cloud environment
- attempted `client` build, but `tsc` is not available in this cloud environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35190a11-b156-4deb-b982-e0c671286fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35190a11-b156-4deb-b982-e0c671286fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

